### PR TITLE
feat: add tsconfig file config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,21 +217,22 @@ This will make no difference when using these types, but this is a special case 
 
 Here is the list of the configuration options you can use in the JSON file:
 
-| Option name                   | Default | Value type    | Description                                                                           |
-| ----------------------------- | ------- | ------------- | ------------------------------------------------------------------------------------- |
-| `apiInputPath`                | -       | `string`      | Path to your API's source folder (e.g. `apps/api`)                                    |
-| `sdkOutput`                   | -       | `string`      | Path to generate the SDK at (e.g. `apps/front/src/sdk`)                               |
-| `sdkInterfacePath`            | -       | `string`      | Path to the SDK interface (e.g. `apps/front/src/sdk-interface.ts`)                    |
-| `magicTypes`                  | `[]`    | `MagicType[]` | Magic types (see below)                                                               |
-| `jsonOutput`                  | `null`  | `string`      | Write the analyzer's output to a file                                                 |
-| `jsonPrettyOutput`            | `null`  | `boolean`     | Prettify the output JSON if the option above is enabled                               |
-| `prettierConfig`              | `null`  | `string`      | Use a specific Prettier config (otherwise will try to find one in a parent directory) |
-| `prettify`                    | `true`  | `boolean`     | Set to `false` to disable SDK files prettifying                                       |
-| `overwriteOldOutputDir`       | `true`  | `boolean`     | Set to `false` to not remove the old SDK directory when re-generating it              |
-| `generateDefaultSdkInterface` | `true`  | `boolean`     | Set to `false` to not generate a default SDK interface when it does not exist yet     |
-| `generateTimestamps`          | `true`  | `boolean`     | Set to `false` to not put the timestamp in the generated SDK files                    |
-| `verbose`                     | `false` | `boolean`     | Display verbose informations                                                          |
-| `noColor`                     | `false` | `boolean`     | Disable colored output                                                                |
+| Option name                   | Default         | Value type    | Description                                                                           |
+| ----------------------------- | -------         | ------------- | ------------------------------------------------------------------------------------- |
+| `apiInputPath`                | -               | `string`      | Path to your API's source folder (e.g. `apps/api`)                                    |
+| `sdkOutput`                   | -               | `string`      | Path to generate the SDK at (e.g. `apps/front/src/sdk`)                               |
+| `sdkInterfacePath`            | -               | `string`      | Path to the SDK interface (e.g. `apps/front/src/sdk-interface.ts`)                    |
+| `magicTypes`                  | `[]`            | `MagicType[]` | Magic types (see below)                                                               |
+| `jsonOutput`                  | `null`          | `string`      | Write the analyzer's output to a file                                                 |
+| `jsonPrettyOutput`            | `null`          | `boolean`     | Prettify the output JSON if the option above is enabled                               |
+| `prettierConfig`              | `null`          | `string`      | Use a specific Prettier config (otherwise will try to find one in a parent directory) |
+| `prettify`                    | `true`          | `boolean`     | Set to `false` to disable SDK files prettifying                                       |
+| `tsconfigFile`                | `tsconfig.json` | `string`      | Use a custom tsconfig file                                                            |
+| `overwriteOldOutputDir`       | `true`          | `boolean`     | Set to `false` to not remove the old SDK directory when re-generating it              |
+| `generateDefaultSdkInterface` | `true`          | `boolean`     | Set to `false` to not generate a default SDK interface when it does not exist yet     |
+| `generateTimestamps`          | `true`          | `boolean`     | Set to `false` to not put the timestamp in the generated SDK files                    |
+| `verbose`                     | `false`         | `boolean`     | Display verbose informations                                                          |
+| `noColor`                     | `false`         | `boolean`     | Disable colored output                                                                |
 
 ## Magic types
 

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -45,10 +45,11 @@ export async function analyzerCli(config: Config): Promise<SdkContent> {
   }
 
   // ====== Find & parse 'tsconfig.json' ====== //
-  const tsConfigFilePath = path.join(sourcePath, 'tsconfig.json')
+  const tsConfigFileName = config.tsconfigFile || 'tsconfig.json'
+  const tsConfigFilePath = path.join(sourcePath, tsConfigFileName)
 
   if (!fs.existsSync(tsConfigFilePath)) {
-    panic('No {yellow} file found in provided source path {yellow}', 'tsconfig.json', sourcePath)
+    panic('No {yellow} file found in provided source path {yellow}', tsConfigFileName, sourcePath)
   }
 
   // Create a 'ts-morph' project

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,9 @@ export interface Config {
   /** Path to Prettier's configuration file */
   readonly prettierConfig?: string
 
+  /** Path to custom tsconfig file */
+  readonly tsconfigFile?: string
+
   /** If the output directory already exists, overwrite it (enabled by default) */
   readonly overwriteOldOutputDir?: boolean
 


### PR DESCRIPTION
This allows the user to add a custom tsconfig file path.

Useful when nest makes `tsconfig.app.json` files.