### PR TITLE
feat: add return type to sdk-interface

### DIFF
--- a/src/generator/sdk-interface.ts
+++ b/src/generator/sdk-interface.ts
@@ -1,10 +1,10 @@
 export const defaultSdkInterface = `
-export async function request(
+export async function request<T = unknown>(
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   uri: string,
   body: unknown,
   query: Record<string, string>
-): Promise<any> {
+): Promise<T> {
   const url = new URL('http://localhost:3000' + uri)
   url.search = new URLSearchParams(query).toString()
 


### PR DESCRIPTION
This allows the generated data controllers to better understand the type of the request