### PR TITLE
Fix type file path under windows

### DIFF
--- a/src/generator/genmodules.ts
+++ b/src/generator/genmodules.ts
@@ -77,7 +77,9 @@ export function generateSdkModules(modules: SdkModules): Map<string, string> {
       }
 
       for (const [file, types] of imports) {
-        out.push(`import type { ${types.join(', ')} } from "../_types/${normalizeExternalFilePath(file.replace(/\\/g, '/'))}";`)
+        out.push(
+          `import type { ${types.join(', ')} } from "../_types/${normalizeExternalFilePath(file.replace(/\\/g, '/')).replace(/\\/g, '/')}";`
+        )
       }
 
       out.push('')


### PR DESCRIPTION
Fix for this issue: https://github.com/lonestone/nest-sdk-generator/issues/2