### PR TITLE
Move Win32 '//' output fix into Prettier handler

### DIFF
--- a/src/generator/genmodules.ts
+++ b/src/generator/genmodules.ts
@@ -77,9 +77,7 @@ export function generateSdkModules(modules: SdkModules): Map<string, string> {
       }
 
       for (const [file, types] of imports) {
-        out.push(
-          `import type { ${types.join(', ')} } from "../_types/${normalizeExternalFilePath(file.replace(/\\/g, '/')).replace(/\\/g, '/')}";`
-        )
+        out.push(`import type { ${types.join(', ')} } from "../_types/${normalizeExternalFilePath(file.replace(/\\/g, '/'))}";`)
       }
 
       out.push('')

--- a/src/generator/prettier.ts
+++ b/src/generator/prettier.ts
@@ -1,7 +1,7 @@
 /**
  * @file Interface for prettifying generated files
  */
-
+import * as os from 'os'
 import * as fs from 'fs'
 import * as prettier from 'prettier'
 import { Config } from '../config'
@@ -39,6 +39,14 @@ export function findPrettierConfig(config: Config): object {
  * @returns
  */
 export function prettify(source: string, config: object, parser: 'typescript' | 'json'): string {
+  // Fix prettier // to /
+  if (os.platform() === 'win32') {
+    return prettier.format(source.replace(/\\/g, '/'), {
+      parser,
+      ...config,
+    })
+  }
+
   return prettier.format(source, {
     parser,
     ...config,


### PR DESCRIPTION
Problem:
- After using it a while, I found that my previous Windows Path fix has some side-effects on later typescript type resolve.

Solution:
- I moved the path correction right before the Prettier formatter, to ensure that it has no side-effects internally.

- [x] Tested on a mid-size NestJS project